### PR TITLE
Stringify with loader-utils, call toString if necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
     "webpack",
     "to-string"
   ],
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "dependencies": {
+    "loader-utils": "^0.2.16"
+  }
 }

--- a/src/to-string.js
+++ b/src/to-string.js
@@ -1,7 +1,25 @@
+var loaderUtils = require("loader-utils");
+
 /**
- * @see https://github.com/webpack/webpack/wiki/Loader-Specification
+ * @see https://webpack.github.io/docs/loaders.html
  */
-module.exports = function (content) {
-    this.cacheable();
-    return 'module.exports = ' + JSON.stringify(this.exec(content, this.resource).toString());
+module.exports = function() {}
+
+/**
+ * @see https://webpack.github.io/docs/loaders.html#pitching-loader
+ */
+module.exports.pitch = function(remainingRequest) {
+    if (this.cacheable) {
+        this.cacheable();
+    }
+
+    return `
+        var result = require(${loaderUtils.stringifyRequest(this, "!!" + remainingRequest)});
+
+        if (typeof result === "string") {
+            module.exports = result;
+        } else {
+            module.exports = result.toString();
+        }
+    `;
 };


### PR DESCRIPTION
Fixes #2, and #6.

I've taken it for a spin and it's working great on an ng2 project I'm working on. This solution has been "inspired" by the folks over in #2. I just figured that this should probably end up back in here, as there are quite a few tutorials that recommend using this loader, and it doesn't really make much sense to have a bunch of loaders doing the same thing when we could just update this one.