### PR TITLE
feat(sourcemaps): add support for pass through of sourcemaps

### DIFF
--- a/src/to-string.js
+++ b/src/to-string.js
@@ -12,12 +12,17 @@ module.exports.pitch = function(remainingRequest) {
     if (this.cacheable) {
         this.cacheable();
     }
+    const query = loaderUtils.parseQuery(this.query);
 
     return `
         var result = require(${loaderUtils.stringifyRequest(this, "!!" + remainingRequest)});
 
         if (typeof result === "string") {
             module.exports = result;
+        } else if (${query.sourceMap}) {
+            module.exports = \`\${result[0][1]}
+
+\${"/\\\*\#"} sourceMappingURL=data:application/json;base64,\${btoa(JSON.stringify(result[0][3]))} */\`;
         } else {
             module.exports = result.toString();
         }

--- a/src/to-string.js
+++ b/src/to-string.js
@@ -22,7 +22,8 @@ module.exports.pitch = function(remainingRequest) {
         } else if (${query.sourceMap}) {
             module.exports = \`\${result[0][1]}
 
-\${"/\\\*\#"} sourceMappingURL=data:application/json;base64,\${btoa(JSON.stringify(result[0][3]))} */\`;
+\${"/\\\*\#"}
+sourceMappingURL=data:application/json;base64,\${btoa(JSON.stringify(result[0][3]))} */\`;
         } else {
             module.exports = result.toString();
         }

--- a/src/to-string.js
+++ b/src/to-string.js
@@ -20,10 +20,13 @@ module.exports.pitch = function(remainingRequest) {
         if (typeof result === "string") {
             module.exports = result;
         } else if (${query.sourceMap}) {
-            module.exports = \`\${result[0][1]}
-
-\${"/\\\*\#"}
-sourceMappingURL=data:application/json;base64,\${btoa(JSON.stringify(result[0][3]))} */\`;
+            module.exports = [
+              result[0][1],
+              "\\n\\n/\\\*\#\\n",
+              "sourceMappingURL=data:application/json;base64,",
+              btoa(JSON.stringify(result[0][3])),
+              " */"
+            ].join("");
         } else {
             module.exports = result.toString();
         }


### PR DESCRIPTION
Adds simple extraction of sourcemaps with https://github.com/webpack-contrib/css-loader delivers #11 

Sample config:
```javascript
{
          test: /\.css$/,
          use: ['to-string-loader?sourceMap', `css-loader?${JSON.stringify({ sourceMap: true, importLoaders: 1 })}`],
        }
```

Dev console with angular 2 build:
![image](https://cloud.githubusercontent.com/assets/4655972/23200196/0809f5f8-f8a1-11e6-8c1a-153f45ab9973.png)
