### PR TITLE
fix: fix compatibility issue with css-loader v4

### DIFF
--- a/src/to-string.js
+++ b/src/to-string.js
@@ -16,6 +16,10 @@ module.exports.pitch = function(remainingRequest) {
     return `
         var result = require(${loaderUtils.stringifyRequest(this, "!!" + remainingRequest)});
 
+        if (result && result.__esModule) {
+            result = result.default;
+        }
+
         if (typeof result === "string") {
             module.exports = result;
         } else {


### PR DESCRIPTION
css-loader v4 changed default option esModule from false to true. to-string-loader wrongly outputs "[object object]".